### PR TITLE
fixing console prompting y/n/c for token regeneration

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -77,7 +77,7 @@ ask_refresh <- function(reason, error_message) {
 
   do_refresh <- askYesNo(
     "Would you like to generate a new token?",
-    default = FALSE,
+    default = TRUE,
     prompts = c("y", "n", "c")
   )
 


### PR DESCRIPTION
Closes #5 

update to ask yes no to default to TRUE to not require console prompt